### PR TITLE
fixed timestamp scanning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eac.js",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.1",
   "description": "Commnandline tool to interact with the Ethereum Alarm Clock contracts.",
   "main": "./src/index.js",
   "scripts": {

--- a/src/client/scanning.js
+++ b/src/client/scanning.js
@@ -30,7 +30,7 @@ const scanBlockchain = async conf => {
 	scan(conf, leftBlock, rightBlock)
 	scan(conf, leftTimestamp, rightTimestamp)
 }
-
+ 
 const scan = async (conf, left, right) => {
 	const log = conf.logger
 	const web3 = conf.web3

--- a/src/client/scanning.js
+++ b/src/client/scanning.js
@@ -16,9 +16,24 @@ const scanBlockchain = async conf => {
 	const log = conf.logger
 	const web3 = conf.web3
 
-	const left = (await eac.Util.getBlockNumber(web3)) - conf.scanSpread
-	const right = left + conf.scanSpread * 2
-	log.debug(`Scanning bounds from ${left} to ${right}`)
+	const leftBlock = (await eac.Util.getBlockNumber(web3)) - conf.scanSpread
+	const rightBlock = leftBlock + conf.scanSpread * 2
+
+	const leftTimestamp = await eac.Util.getTimestampForBlock(web3, leftBlock)
+	const avgBlockTime = Math.floor(await eac.Util.getTimestamp(web3) - leftTimestamp / conf.scanSpread)
+	const rightTimestamp = Math.floor(leftTimestamp + avgBlockTime * conf.scanSpread * 2)
+
+	log.debug(`Scanning bounds from 
+[debug] blocks: ${leftBlock} to ${rightBlock}
+[debug] timestamps: ${leftTimestamp} tp ${rightTimestamp}`)
+
+	scan(conf, leftBlock, rightBlock)
+	scan(conf, leftTimestamp, rightTimestamp)
+}
+
+const scan = async (conf, left, right) => {
+	const log = conf.logger
+	const web3 = conf.web3
 
 	const requestTracker = conf.tracker
 	const requestFactory = conf.factory
@@ -67,8 +82,9 @@ const scanBlockchain = async conf => {
 			// This request is within bounds, store it.
 			store(conf, txRequest)
 		} else {
+			console.log
 			log.debug(
-				`Scan exit condition hit! Next window start exceeds right bound.`
+				`Scan exit condition hit! Next window start exceeds right bound. WindowStart: ${txRequest.windowStart} | right: ${right}`
 			)
 			break
 		}

--- a/src/util.js
+++ b/src/util.js
@@ -69,6 +69,19 @@ const getTimestamp = web3 => {
 	})
 }
 
+const getTimestampForBlock = async (web3, blockNum) => {
+	const curBlockNum = await getBlockNumber(web3)
+	if (blockNum > curBlockNum) {
+		throw new Error(`Must pass in a blocknumber at or lower than the current blocknumber. Now: ${curBlockNum} | Tried: ${blockNum}`)
+	}
+	return new Promise((resolve, reject) => {
+		web3.eth.getBlock(blockNum, (err, block) => {
+			if (!err) resolve(block.timestamp)
+			else reject(err)
+		})
+	})
+}
+
 const getTxRequestFromReceipt = receipt => {
 	const log = receipt.logs.find(log => {
 		return log.topics[0] === Constants.NEWREQUESTLOG
@@ -127,6 +140,7 @@ module.exports = {
 	getChainName,
 	getGasPrice,
 	getTimestamp,
+	getTimestampForBlock,
 	getTxRequestFromReceipt,
 	waitForTransactionToBeMined,
 }


### PR DESCRIPTION
Fixes a problem with the scanner where it wouldn't pick up any timestamp scheduled requests due to them being out of bounds. The fix in this case was to abstract out the scan logic and run it twice, once for the block bounds and again for the timestamp bounds. The timestamps are assumed from the blocks and the --scan <spread> option still __only__ takes block numbers.