### PR TITLE
1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eac.js",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Commnandline tool to interact with the Ethereum Alarm Clock contracts.",
   "main": "./src/index.js",
   "scripts": {

--- a/src/cli/eac.js
+++ b/src/cli/eac.js
@@ -19,7 +19,7 @@ const log = {
 
 // Parse the command line options using commander.
 program
-	.version("1.0.5")
+	.version("1.1.0")
 	// Client options
 	.option("-c, --client", "starts the executing client")
 	.option(

--- a/src/cli/eac.js
+++ b/src/cli/eac.js
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
 const program = require("commander")
-
 const alarmClient = require("../client/main")
-const eac = require("../index")()
-
 const BigNumber = require("bignumber.js")
 const clear = require("clear")
 const ora = require("ora")
@@ -20,6 +17,7 @@ const log = {
 	fatal: msg => console.log(`[FATAL] ${msg}`),
 }
 
+// Parse the command line options using commander.
 program
 	.version("1.0.5")
 	// Client options
@@ -47,6 +45,7 @@ program
 	.option("--timestamp")
 	.parse(process.argv)
 
+// Create the web3 object by using the chosen provider, defaults to localhost:8545
 const Web3 = require("web3")
 const provider = new Web3.providers.HttpProvider(`${program.provider}`)
 const web3 = new Web3(provider)
@@ -114,8 +113,11 @@ const main = async _ => {
 			process.exit(1)
 		}
 		if (!checkForUnlockedAccount(web3)) process.exit(1)
-		const chain = eac.Util.getChainName(web3)
-		const eacScheduler = new eac.Scheduler(web3, chain)
+
+		// Init the eac object by passing in the web3 object.
+		const eac = require("../index")(web3)
+
+		const eacScheduler = await eac.scheduler()
 
 		// Starts the scheduling wizard.
 		clear()
@@ -181,7 +183,7 @@ const main = async _ => {
 			windowSize = 255
 		}
 
-		const blockNum = await eac.Util.getBlockNumber(web3)
+		const blockNum = await eac.Util.getBlockNumber()
 		let windowStart = readlineSync.question(
 			`Enter window start: [Current block number - ${blockNum}\n`
 		)
@@ -223,7 +225,7 @@ const main = async _ => {
 
 		clear()
 
-		const endowment = eacScheduler.calcEndowment(
+		const endowment = eac.Util.calcEndowment(
 			new BigNumber(callGas),
 			new BigNumber(callValue),
 			new BigNumber(gasPrice),

--- a/src/cli/eac.js
+++ b/src/cli/eac.js
@@ -3,7 +3,7 @@
 const program = require("commander")
 
 const alarmClient = require("../client/main")
-const eac = require("../index")
+const eac = require("../index")()
 
 const BigNumber = require("bignumber.js")
 const clear = require("clear")

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -2,7 +2,6 @@ const Config = require("./config")
 const Repl = require("./repl")
 const Scanner = require("./scanning")
 const StatsDB = require("./statsdb")
-const eac = require("../index")()
 
 const startScanning = (ms, conf) => {
 	const log = conf.logger
@@ -30,7 +29,7 @@ const startScanning = (ms, conf) => {
 
 /**
  * The main driver function that begins the client operation.
- * @param {*} web3 An instantiated web3 instance.
+ * @param {Web3} web3 An instantiated web3 instance.
  * @param {String} provider The supplied provider host for the web3 instance. (Ex. 'http://localhost:8545)
  * @param {Number} scanSpread The spread +- of the current block number to scan.
  * @param {Number} ms Milliseconds between each conduction of a blockchain scan.
@@ -50,8 +49,9 @@ const main = async (
 	walletFile,
 	pw
 ) => {
+	const eac = require("../index")(web3)
 	// Assigns chain to the name of the network ID
-	const chain = eac.Util.getChainName(web3)
+	const chain = eac.Util.getChainName()
 
 	// Loads the contracts
 	let requestFactory, requestTracker
@@ -60,15 +60,15 @@ const main = async (
 			throw new Error("Not implemented.")
 			break
 		case "ropsten":
-			requestFactory = eac.RequestFactory.initRopsten(web3)
-			requestTracker = eac.RequestTracker.initRopsten(web3)
+			requestFactory = await eac.requestFactory()
+			requestTracker = await eac.requestTracker()
 			break
 		case "rinkeby":
 			throw new Error("Not implemented.")
 			break
 		case "kovan":
-			requestFactory = eac.RequestFactory.initKovan(web3)
-			requestTracker = eac.RequestTracker.initKovan(web3)
+			requestFactory = await eac.requestFactory()
+			requestTracker = await eac.requestTracker()
 			break
 		default:
 			throw new Error(`Chain value: ${chain} not valid.`)
@@ -120,7 +120,7 @@ const main = async (
 	}
 	console.log(
 		`${account} | Balance: ${web3.fromWei(
-			await eac.Util.getBalance(conf.web3, account)
+			await eac.Util.getBalance(account)
 		)}`
 	)
 	conf.statsdb.initialize([account])

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -51,7 +51,7 @@ const main = async (
 ) => {
 	const eac = require("../index")(web3)
 	// Assigns chain to the name of the network ID
-	const chain = eac.Util.getChainName()
+	const chain = await eac.Util.getChainName()
 
 	// Loads the contracts
 	let requestFactory, requestTracker

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -2,7 +2,7 @@ const Config = require("./config")
 const Repl = require("./repl")
 const Scanner = require("./scanning")
 const StatsDB = require("./statsdb")
-const eac = require("../index")
+const eac = require("../index")()
 
 const startScanning = (ms, conf) => {
 	const log = conf.logger

--- a/src/client/repl.js
+++ b/src/client/repl.js
@@ -1,5 +1,5 @@
 const repl = require("repl")
-const eac = require("../index")
+const eac = require("../index")()
 
 const start = (conf, ms) => {
 	const web3 = conf.web3

--- a/src/client/repl.js
+++ b/src/client/repl.js
@@ -1,8 +1,8 @@
 const repl = require("repl")
-const eac = require("../index")()
 
 const start = (conf, ms) => {
 	const web3 = conf.web3
+	const eac = require("../index")(web3)
 
 	console.log(" ") //blank space
 	const replServer = repl.start({ prompt: ">> " })
@@ -14,7 +14,7 @@ const start = (conf, ms) => {
 				conf.wallet.getAccounts().forEach(async account => {
 					console.log(
 						`${account} | Balance: ${web3.fromWei(
-							await eac.Util.getBalance(web3, account)
+							await eac.Util.getBalance(account)
 						)}`
 					)
 				})
@@ -22,7 +22,7 @@ const start = (conf, ms) => {
 				const account = web3.eth.defaultAccount
 				console.log(
 					`${account} | Balance: ${web3.fromWei(
-						await eac.Util.getBalance(web3, account)
+						await eac.Util.getBalance(account)
 					)}`
 				)
 			}
@@ -128,7 +128,7 @@ const start = (conf, ms) => {
 				console.log("Must pass a valid transaction request address")
 				return
 			}
-			const txRequest = new eac.TxRequest(txRequestAddr, web3)
+			const txRequest = await eac.transactionRequest(txRequestAddr)
 			try {
 				await txRequest.fillData()
 				console.log(`

--- a/src/client/routing.js
+++ b/src/client/routing.js
@@ -1,7 +1,7 @@
 const BigNumber = require("bignumber.js")
 const hasPending = require("./pending.js")
 
-const { Util } = require("../index")
+const { Util } = require("../index")()
 
 /**
  * Takes in a txRequest object and routes it to the thread that will act on it,

--- a/src/client/scanning.js
+++ b/src/client/scanning.js
@@ -1,5 +1,5 @@
 const { BigNumber } = require("bignumber.js")
-const eac = require("../index")
+const eac = require("../index")()
 
 const store = (conf, txRequest) => {
 	const log = conf.logger

--- a/src/client/scanning.js
+++ b/src/client/scanning.js
@@ -114,10 +114,13 @@ const scanCache = async conf => {
 
 	const allTxRequests = conf.cache
 		.stored()
-		.map(address => await eac.transactionRequest(address))
+		.map(address => eac.transactionRequest(address))
 
-	allTxRequests.forEach(txRequest => {
-		txRequest.refreshData().then(_ => routeTxRequest(conf, txRequest))
+	Promise.all(allTxRequests)
+	.then(txRequests => {
+		txRequests.forEach(txRequest => {
+			txRequest.refreshData().then(_ => routeTxRequest(conf, txRequest))
+		})
 	})
 }
 

--- a/src/client/statsdb.js
+++ b/src/client/statsdb.js
@@ -1,7 +1,7 @@
 const BigNumber = require("bignumber.js")
 const loki = require("lokijs")
 
-const eac = require("../index")
+const eac = require("../index")()
 
 /// Wrapper over a lokijs persistent storage to keep track of the stats of executing accounts.
 class StatsDB {

--- a/src/client/statsdb.js
+++ b/src/client/statsdb.js
@@ -1,20 +1,19 @@
 const BigNumber = require("bignumber.js")
 const loki = require("lokijs")
 
-const eac = require("../index")()
-
 /// Wrapper over a lokijs persistent storage to keep track of the stats of executing accounts.
 class StatsDB {
 	constructor(web3) {
 		this.db = new loki("stats.json")
 		this.stats = this.db.addCollection("stats")
 		this.web3 = web3
+		this.eac = require('../index')(web3)
 	}
 
 	/// Takes an arry of addresses and stores them as new stats objects.
 	initialize(accounts) {
 		accounts.forEach(async account => {
-			let bal = await eac.Util.getBalance(this.web3, account)
+			let bal = await this.eac.Util.getBalance(account)
 			bal = new BigNumber(bal)
 			this.stats.insert({
 				account: account,
@@ -30,7 +29,7 @@ class StatsDB {
 	async updateClaimed(account) {
 		const found = this.stats.find({ account: account })[0]
 		found.claimed++
-		let bal = await eac.Util.getBalance(this.web3, account)
+		let bal = await this.eac.Util.getBalance(account)
 		bal = new BigNumber(bal)
 		const difference = bal.minus(found.currentEther)
 		found.currentEther = found.currentEther.plus(difference)
@@ -41,7 +40,7 @@ class StatsDB {
 	async updateExecuted(account) {
 		const found = this.stats.find({ account: account })[0]
 		found.executed++
-		let bal = await eac.Util.getBalance(this.web3, account)
+		let bal = await this.eac.Util.getBalance(account)
 		bal = new BigNumber(bal)
 		const difference = bal.minus(found.currentEther)
 		found.currentEther = found.currentEther.plus(difference)

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,39 @@ const Scheduler = require("./scheduling")
 const TxRequest = require("./txRequest")
 const Util = require("./util")
 
-module.exports = {
-	Constants,
-	RequestFactory,
-	RequestTracker,
-	Scheduler,
-	TxRequest,
-	Util,
+module.exports = web3 => {
+
+	if (!web3) {
+		return new Object({
+			Constants,
+			RequestFactory,
+			RequestTracker,
+			Scheduler,
+			TxRequest,
+			Util: Util(),
+		})
+	}
+
+	const util = Util(web3)
+	return new Object({
+		Constants,
+		requestFactory: async () => {
+			const chainName = await util.getChainName()
+			const contracts = require(`./assets/${chainName}.json`)
+			return new RequestFactory(contracts.requestFactory, web3)
+		},
+		requestTracker: async () => {
+			const chainName = await util.getChainName()
+			const contracts = require(`./assets/${chainName}.json`)
+			return new RequestTracker(contracts.requestTracker, web3)
+		},
+		scheduler: async () => {
+			const chainName = await util.getChainName()
+			return new Scheduler(web3, chainName)
+		},
+		transactionRequest: (address) => {
+			return new TxRequest(address, web3)
+		},
+		Util: util,
+	})
 }

--- a/src/requestFactory/index.js
+++ b/src/requestFactory/index.js
@@ -1,5 +1,5 @@
 const Constants = require("../constants")
-const Util = require("../util")
+const Util = require("../util")()
 
 class RequestFactory {
 	constructor(address, web3) {
@@ -43,7 +43,6 @@ class RequestFactory {
 		})
 	}
 
-	
 	validateRequestParams(addressArgs, uintArgs, callData, endowment) {
 		return new Promise((resolve, reject) => {
 			this.instance.validateRequestParams.call(

--- a/src/requestTracker/index.js
+++ b/src/requestTracker/index.js
@@ -1,6 +1,6 @@
 const { BigNumber } = require("bignumber.js")
 const Constants = require("../constants")
-const Util = require("../util")
+const Util = require("../util")()
 
 class RequestTracker {
 	constructor(address, web3) {

--- a/src/scheduling/index.js
+++ b/src/scheduling/index.js
@@ -1,5 +1,5 @@
 const BigNumber = require("bignumber.js")
-const Util = require("../util")
+const Util = require("../util")()
 
 class Scheduler {
 	constructor(web3, chain) {

--- a/src/txRequest/txRequest.js
+++ b/src/txRequest/txRequest.js
@@ -3,7 +3,7 @@ const { BigNumber } = require("bignumber.js")
 const RequestData = require("./requestData")
 
 const Constants = require("../constants")
-const Util = require("../util")
+const Util = require("../util")()
 
 class TxRequest {
 	constructor(address, web3) {

--- a/src/util.js
+++ b/src/util.js
@@ -97,19 +97,26 @@ const getTxRequestFromReceipt = receipt => {
  * @param {Web3} web3
  */
 const getChainName = web3 => {
-	const networkID = web3.version.network
-	if (networkID == 1) {
-		// return 'mainnet'
-		throw new Error("Not implemented for mainnet")
-	} else if (networkID == 3) {
-		return "ropsten"
-	} else if (networkID == 4) {
-		return "rinkeby"
-	} else if (networkID == 42) {
-		return "kovan"
-	} else {
-		throw new Error("Invalid network.")
-	}
+	return new Promise((resolve, reject) => {
+		web3.version.getNetwork((err, netID) => {
+			if (!err) {
+				if (netID == 1) {
+					// return 'mainnet'
+					reject("Not implemented for mainnet")
+				} else if (netID == 3) {
+					 resolve("ropsten")
+				} else if (netID == 4) {
+					 resolve("rinkeby")
+				} else if (netID == 42) {
+					 resolve("kovan")
+				} else if (netID > 1517361627) {
+					resolve("tester")
+				} else {
+					reject(err)
+				}
+			}
+		})
+	})
 }
 
 const waitForTransactionToBeMined = (web3, txHash, interval) => {
@@ -132,17 +139,36 @@ const waitForTransactionToBeMined = (web3, txHash, interval) => {
 	})
 }
 
-module.exports = {
-	checkNotNullAddress,
-	checkValidAddress,
-	estimateGas,
-	getABI,
-	getBalance,
-	getBlockNumber,
-	getChainName,
-	getGasPrice,
-	getTimestamp,
-	getTimestampForBlock,
-	getTxRequestFromReceipt,
-	waitForTransactionToBeMined,
+module.exports = web3 => {
+	if (!web3) {
+		return new Object({
+			checkNotNullAddress,
+			checkValidAddress,
+			estimateGas,
+			getABI,
+			getBalance,
+			getBlockNumber,
+			getChainName,
+			getGasPrice,
+			getTimestamp,
+			getTimestampForBlock,
+			getTxRequestFromReceipt,
+			waitForTransactionToBeMined,
+		})
+	}
+
+	return new Object({
+		checkNotNullAddress,
+		checkValidAddress,
+		estimateGas: opts => estimateGas(web3, opts),
+		getABI,
+		getBalance: address => getBalance(address),
+		getBlockNumber: () => getBlockNumber(web3),
+		getChainName: () => getChainName(web3),
+		getGasPrice: () => getGasPrice(web3),
+		getTimestamp: () => getTimestamp(web3),
+		getTimestampForBlock: blockNum => getTimestampForBlock(web3, blockNum),
+		getTxRequestFromReceipt,
+		waitForTransactionToBeMined: txHash => waitForTransactionToBeMined(web3, txHash)
+	})
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,20 @@
+const { BigNumber } = require('bignumber.js')
 const Constants = require("./constants.js")
 const ethUtil = require("ethereumjs-util")
+
+const calcEndowment = (callGas, callValue, gasPrice, donation, payment) => {
+	callGas = new BigNumber(callGas)
+	callValue = new BigNumber(callValue)
+	gasPrice = new BigNumber(gasPrice)
+	donation = new BigNumber(donation)
+	payment = new BigNumber(payment)
+
+	return payment
+		.plus(donation.times(2))
+		.plus(callGas.times(gasPrice))
+		.plus(gasPrice.times(180000))
+		.plus(callValue)
+}
 
 const checkNotNullAddress = address => {
 	if (address === Constants.NULL_ADDRESS) return false
@@ -142,6 +157,7 @@ const waitForTransactionToBeMined = (web3, txHash, interval) => {
 module.exports = web3 => {
 	if (!web3) {
 		return new Object({
+			calcEndowment,
 			checkNotNullAddress,
 			checkValidAddress,
 			estimateGas,
@@ -158,6 +174,7 @@ module.exports = web3 => {
 	}
 
 	return new Object({
+		calcEndowment,
 		checkNotNullAddress,
 		checkValidAddress,
 		estimateGas: opts => estimateGas(web3, opts),

--- a/src/util.js
+++ b/src/util.js
@@ -179,7 +179,7 @@ module.exports = web3 => {
 		checkValidAddress,
 		estimateGas: opts => estimateGas(web3, opts),
 		getABI,
-		getBalance: address => getBalance(address),
+		getBalance: address => getBalance(web3, address),
 		getBlockNumber: () => getBlockNumber(web3),
 		getChainName: () => getChainName(web3),
 		getGasPrice: () => getGasPrice(web3),

--- a/test/requestFactory.js
+++ b/test/requestFactory.js
@@ -2,7 +2,7 @@ const BigNumber = require("bignumber.js")
 const Deployer = require("../deploy.js")
 const expect = require("chai").expect
 
-const eac = require("../src")
+const eac = require("../src")()
 
 describe("Request Factory", () => {
 	let rfAddr

--- a/test/requestFactory.js
+++ b/test/requestFactory.js
@@ -5,24 +5,24 @@ const expect = require("chai").expect
 const eac = require("../src")()
 
 describe("Request Factory", () => {
-	let rfAddr
+	let eac
 	let web3
 
 	before(async () => {
 		const deployed = await Deployer()
 		web3 = deployed.web3
-		rfAddr = deployed.requestFactory.address
+		eac = require('../src')(web3)
 	})
 
-	it("Ensures that requestFactory is valid", () => {
-		const requestFactory = new eac.RequestFactory(rfAddr, web3)
+	it("Ensures that requestFactory is valid", async () => {
+		const requestFactory = await eac.requestFactory()
 		expect(requestFactory.address).to.exist
 	})
 
 	it("tests RequestFactory.isKnownRequest()", async () => {
 		// To test `isKnownRequest()` we have to use the scheduler to deploy a
 		// new instance of a TxRequest.
-		const eacScheduler = new eac.Scheduler(web3, "tester")
+		const eacScheduler = await eac.scheduler()
 
 		const toAddress = "0xDacC9C61754a0C4616FC5323dC946e89Eb272302"
 		const callData = "0x" + Buffer.from("callData").toString("hex")
@@ -64,13 +64,10 @@ describe("Request Factory", () => {
 
 		expect(receipt.status).to.equal(1)
 
-		const newRequestAddress = "0x".concat(receipt.logs[0].data.slice(-40))
 
-		// This is to get around an issue with the deploy script. It deploys new instances
-		// of the contracts in between each test so it messes up keeping the right
-		// addresses. Need a better solution but for now this is a workaround.
-		const rfAddr2 = await eacScheduler.getFactoryAddress()
-		const requestFactory = new eac.RequestFactory(rfAddr2, web3)
+		const newRequestAddress = eac.Util.getTxRequestFromReceipt(receipt)
+
+        const requestFactory = await eac.requestFactory()
 
 		// Now that we've got the address of our new request, we can check it against
 		// the request factory.
@@ -79,7 +76,7 @@ describe("Request Factory", () => {
 	})
 
 	it("tests RequestFactory.validateRequestParams()", async () => {
-        const requestFactory = new eac.RequestFactory(rfAddr, web3)
+        const requestFactory = await eac.requestFactory()
         expect(requestFactory.address).to.exist
 
         // First test that `.parseIsValid()` works.
@@ -150,7 +147,7 @@ describe("Request Factory", () => {
             requiredDeposit
         ]
 
-        const endowment = eac.Scheduler.calcEndowment(
+        const endowment = eac.Util.calcEndowment(
             new BigNumber(callGas),
 			new BigNumber(callValue),
 			new BigNumber(gasPrice),

--- a/test/requestTracker.js
+++ b/test/requestTracker.js
@@ -2,38 +2,37 @@ const BigNumber = require("bignumber.js")
 const Deployer = require("../deploy.js")
 const expect = require("chai").expect
 
-const eac = require("../src")()
-
 describe("Request Tracker", () => {
-	let rtAddr
+	let eac
 	let web3
 
 	before(async () => {
 		const deployed = await Deployer()
 		web3 = deployed.web3
-		rtAddr = deployed.requestTracker
+		eac = require("../src")(web3)
+
 	})
 
 	it("Ensures the request tracker is valid", async () => {
-		const requestTracker = new eac.RequestTracker(rtAddr, web3)
+		const requestTracker = await eac.requestTracker()
 		expect(requestTracker.address).to.exist
 	})
 
 	it("tests requestTrackers methods", async () => {
-		const eacScheduler = new eac.Scheduler(web3, "tester")
+		const eacScheduler = await eac.scheduler()
 
 		const toAddress = "0xDacC9C61754a0C4616FC5323dC946e89Eb272302"
 		const callData = "0x" + Buffer.from("callData").toString("hex")
 		const callGas = 3000000
 		const callValue = 123454321
 		const windowSize = 255
-		const windowStart = (await eac.Util.getBlockNumber(web3)) + 25
+		const windowStart = (await eac.Util.getBlockNumber()) + 25
 		const gasPrice = web3.toWei("55", "gwei")
 		const donation = web3.toWei("120", "finney")
 		const payment = web3.toWei("250", "finney")
 		const requiredDeposit = web3.toWei("50", "finney")
 
-		const endowment = eacScheduler.calcEndowment(
+		const endowment = eac.Util.calcEndowment(
 			new BigNumber(callGas),
 			new BigNumber(callValue),
 			new BigNumber(gasPrice),
@@ -62,19 +61,19 @@ describe("Request Tracker", () => {
 
 		expect(receipt.status).to.equal(1)
 
-		const newRequestAddress = "0x".concat(receipt.logs[0].data.slice(-40))
+		const newRequestAddress = eac.Util.getTxRequestFromReceipt(receipt)
 
-		const rfAddr = await eacScheduler.getFactoryAddress()
-		const requestFactory = new eac.RequestFactory(rfAddr, web3)
-		const rtAddr2 = await requestFactory.getTrackerAddress()
-		const requestTracker = new eac.RequestTracker(rtAddr2, web3)
+		// const rfAddr = await eacScheduler.getFactoryAddress()
+		const requestFactory = await eac.requestFactory()
+		// const rtAddr2 = await requestFactory.getTrackerAddress()
+		const requestTracker = await eac.requestTracker()
 		requestTracker.setFactory(requestFactory.address)
 
-		const left = (await eac.Util.getBlockNumber(web3)) - 10
+		const left = (await eac.Util.getBlockNumber()) - 10
 		const res = await requestTracker.nextFromLeft(left)
 		const resWS = await requestTracker.windowStartFor(res)
 		// The best way to test these is to make a txRequest instance out of them
-		const txRequest = new eac.TxRequest(res, web3)
+		const txRequest = await eac.transactionRequest(res)
 		await txRequest.fillData()
 		expect(txRequest.address).to.exist
 		expect(txRequest.windowStart.toNumber()).to.equal(resWS.toNumber())
@@ -84,7 +83,7 @@ describe("Request Tracker", () => {
 		const res2WS = await requestTracker.windowStartFor(res2)
 		let txRequest2
 		if (res2 !== eac.Constants.NULL_ADDRESS) {
-			txRequest2 = new eac.TxRequest(res2, web3)
+			txRequest2 = await eac.transactionRequest(res2)
 			await txRequest2.fillData()
 			expect(txRequest2.address).to.exist
 			// This txRequest2 should have a later start than txRequest
@@ -97,7 +96,7 @@ describe("Request Tracker", () => {
 		const res3WS = await requestTracker.windowStartFor(res3)
 		let txRequest3
 		if (res3 !== eac.Constants.NULL_ADDRESS) {
-			txRequest3 = new eac.TxRequest(res3, web3)
+			txRequest3 = await eac.transactionRequest(res3)
 			await txRequest3.fillData()
 			expect(txRequest3.address).to.exist
 			// This txRequest3 should have a later start than txRequest2

--- a/test/requestTracker.js
+++ b/test/requestTracker.js
@@ -2,7 +2,7 @@ const BigNumber = require("bignumber.js")
 const Deployer = require("../deploy.js")
 const expect = require("chai").expect
 
-const eac = require("../src")
+const eac = require("../src")()
 
 describe("Request Tracker", () => {
 	let rtAddr

--- a/test/scheduler.js
+++ b/test/scheduler.js
@@ -2,16 +2,14 @@ const BigNumber = require("bignumber.js")
 const Deployer = require("../deploy.js")
 const expect = require("chai").expect
 
-const eac = require("../src")()
-
 describe("Scheduler", () => {
-	let eacScheduler
+	let eac
 	let web3
 
 	before(async () => {
 		const deployed = await Deployer()
 		web3 = deployed.web3
-		eacScheduler = new eac.Scheduler(web3, "tester")
+		eac = require('../src')(web3)
 	})
 
 	it("Calculates the expected endowment", () => {
@@ -27,7 +25,7 @@ describe("Scheduler", () => {
 			.plus(gasPrice.mul(180000))
 			.plus(callValue)
 
-		const endowment = eacScheduler.calcEndowment(
+		const endowment = eac.Util.calcEndowment(
 			callGas,
 			callValue,
 			gasPrice,
@@ -44,19 +42,21 @@ describe("Scheduler", () => {
 		const callGas = 3000000
 		const callValue = 123454321
 		const windowSize = 255
-		const windowStart = (await eac.Util.getBlockNumber(web3)) + 25
+		const windowStart = (await eac.Util.getBlockNumber()) + 25
 		const gasPrice = web3.toWei("55", "gwei")
 		const donation = web3.toWei("120", "finney")
 		const payment = web3.toWei("250", "finney")
 		const requiredDeposit = web3.toWei("50", "finney")
 
-		const endowment = eacScheduler.calcEndowment(
+		const endowment = eac.Util.calcEndowment(
 			new BigNumber(callGas),
 			new BigNumber(callValue),
 			new BigNumber(gasPrice),
 			new BigNumber(donation),
 			new BigNumber(payment)
 		)
+
+		const eacScheduler = await eac.scheduler()
 
 		eacScheduler.initSender({
 			from: web3.eth.defaultAccount,
@@ -89,19 +89,21 @@ describe("Scheduler", () => {
 		const callGas = 3000000
 		const callValue = 123454321
 		const windowSize = 255 * 15
-		const windowStart = (await eac.Util.getTimestamp(web3)) + 25 * 15
+		const windowStart = (await eac.Util.getTimestamp()) + 25 * 15
 		const gasPrice = web3.toWei("55", "gwei")
 		const donation = web3.toWei("120", "finney")
 		const payment = web3.toWei("250", "finney")
 		const requiredDeposit = web3.toWei("50", "finney")
 
-		const endowment = eacScheduler.calcEndowment(
+		const endowment = eac.Util.calcEndowment(
 			new BigNumber(callGas),
 			new BigNumber(callValue),
 			new BigNumber(gasPrice),
 			new BigNumber(donation),
 			new BigNumber(payment)
 		)
+
+		const eacScheduler = await eac.scheduler()
 
 		eacScheduler.initSender({
 			from: web3.eth.defaultAccount,
@@ -128,7 +130,7 @@ describe("Scheduler", () => {
 
 		expect(txRequestAddr).to.exist
 
-		const txRequest = new eac.TxRequest(txRequestAddr, web3)
+		const txRequest = await eac.transactionRequest(txRequestAddr)
 		await txRequest.fillData()
 
 		const winStart = txRequest.windowStart

--- a/test/scheduler.js
+++ b/test/scheduler.js
@@ -2,7 +2,7 @@ const BigNumber = require("bignumber.js")
 const Deployer = require("../deploy.js")
 const expect = require("chai").expect
 
-const eac = require("../src")
+const eac = require("../src")()
 
 describe("Scheduler", () => {
 	let eacScheduler

--- a/test/txRequest.js
+++ b/test/txRequest.js
@@ -3,7 +3,7 @@ const expect = require("chai").expect
 
 const Deployer = require("../deploy")
 
-const eac = require("../src")
+const eac = require("../src")()
 
 describe("TxRequest", () => {
 	let delpoyed

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,25 @@
+const BigNumber = require("bignumber.js")
+const Deployer = require("../deploy.js")
+const expect = require("chai").expect
+
+describe("Util", () => {
+    let eac
+    let web3
+
+	before(async () => {
+		const deployed = await Deployer()
+        web3 = deployed.web3
+        eac = require('../src')(web3)
+    })
+
+    it('tests init without a parameter', () => {
+        const util = require('../src')().Util
+        // console.log(util)
+    })
+
+    // it('tests init', async () => {
+    //     const chainName = await eac.Util.getChainName()
+    //     console.log(chainName)
+
+    // })
+})

--- a/test/util.js
+++ b/test/util.js
@@ -14,6 +14,8 @@ describe("Util", () => {
 
     it('tests init without a parameter', () => {
         const util = require('../src')().Util
+        expect(util)
+        .to.exist
         // console.log(util)
     })
 


### PR DESCRIPTION
Ups eac.js to version 1.1.0, and adds a more intuitive interface to construct the eac object.
Before users would have to initiate each contract class by passing in web3, now webs is passed at initiation of the eac module.
```
const eac = require('eac.js')(web3)
```
For backwards compatibility users can pass in no parameters:
```
const eac = require('eac.js')()
```