### PR TITLE
Added --autostart flag for automated scanning start

### DIFF
--- a/src/cli/eac.js
+++ b/src/cli/eac.js
@@ -34,6 +34,7 @@ program
   .option("-s, --schedule", "schedules a transactions")
   .option("--block")
   .option("--timestamp")
+  .option("--autostart", "starts scanning automatically")
   .parse(process.argv)
 
 // Create the web3 object by using the chosen provider, defaults to localhost:8545
@@ -63,7 +64,8 @@ const main = async (_) => {
       program.logfile,
       program.logLevel, // 1 = debug, 2 = info, 3 = error
       program.wallet,
-      program.password
+      program.password,
+      program.autostart
     ).catch((err) => {
       throw err
     })

--- a/src/client/config.js
+++ b/src/client/config.js
@@ -13,7 +13,8 @@ class Config {
     eac,
     provider,
     walletFile,
-    password
+    password,
+    autostart
   ) {
     this.scanSpread = scanSpread
     this.logger = new Logger(logfile, logLevel)
@@ -24,6 +25,7 @@ class Config {
     this.web3 = web3
     this.eac = eac
     this.provider = provider
+    this.scanning = autostart
     if (walletFile) {
       this.wallet = this.instantiateWallet(walletFile, password)
     }

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -39,6 +39,7 @@ const startScanning = (ms, conf) => {
  * @param {String} chain The name of the chain, accepted values are 'ropsten', 'rinkeby' and 'kovan'.
  * @param {String} walletFile Path to the encrypted wallet file.
  * @param {String} pw Password to decrypt wallet.
+ * @param {Boolean} autoStart Enables automatic scanning.
  */
 const main = async (
   web3,
@@ -49,7 +50,8 @@ const main = async (
   logfile,
   logLevel,
   walletFile,
-  pw
+  pw,
+  autostart
 ) => {
   // Assigns chain to the name of the network ID
   const chain = await eac.Util.getChainName()
@@ -77,7 +79,8 @@ const main = async (
     eac, // conf.eac
     provider, // conf.provider
     walletFile, // conf.wallet
-    pw // wallet password
+    pw,
+    autostart // wallet password
   )
 
   conf.wallet = false
@@ -102,7 +105,6 @@ const main = async (
   conf.statsdb.initialize([account])
 
   // Begin
-  conf.scanning = false
   startScanning(ms, conf)
 
   // Waits a bit before starting the repl so that the accounts have time to print.


### PR DESCRIPTION
Autostart is useful for automated workflows like Docker, now you can start eac.js client from CMD in scanning mode.