### PR TITLE
[FEATURE] Enable instant return of txHash without waiting for mining.

### DIFF
--- a/docs/API/scheduler.md
+++ b/docs/API/scheduler.md
@@ -40,7 +40,7 @@ it in before instead.
 
 See the example below.
 
-### eac.Scheduler.blockSchedule(toAddress, callData, callGas, callValue, windowSize, windowStart, gasPrice, donation, payment, requiredDeposit)
+### eac.Scheduler.blockSchedule(toAddress, callData, callGas, callValue, windowSize, windowStart, gasPrice, donation, payment, requiredDeposit, waitForMined = true)
 
  - `toAddress`     - an Ethereum address
  - `callData`      - hex encoded call data
@@ -52,6 +52,7 @@ See the example below.
  - `donation` - `BigNumber` | String
  - `payment` - `BigNumber` | String
  - `requiredDeposit` - `BigNumber` | String
+ - `waitForMined` - Boolean
 
 Returns a `Promise` that will resolve to the `receipt` of the transaction if successful.
 
@@ -84,7 +85,7 @@ const receipt = await eacScheduler.blockSchedule(
 )
 ```
 
-### eac.Scheduler.timestampSchedule(toAddress, callData, callGas, callValue, windowSize, windowStart, gasPrice, donation, payment, requiredDeposit)
+### eac.Scheduler.timestampSchedule(toAddress, callData, callGas, callValue, windowSize, windowStart, gasPrice, donation, payment, requiredDeposit, waitForMined = true)
 
  - `toAddress`     - an Ethereum address
  - `callData`      - hex encoded call data
@@ -96,5 +97,6 @@ const receipt = await eacScheduler.blockSchedule(
  - `donation` - `BigNumber` | String
  - `payment` - `BigNumber` | String
  - `requiredDeposit` - `BigNumber` | String
+ - `waitForMined` - Boolean
 
 Returns a `Promise` that will resolve to the `receipt` of the transaction if successful.

--- a/src/scheduling/index.js
+++ b/src/scheduling/index.js
@@ -83,10 +83,17 @@ class Scheduler {
         (err, txHash) => {
           if (err) reject(err)
           else {
+            const miningPromise = Util.waitForTransactionToBeMined(this.web3, txHash);
+
             if (waitForMined) {
-              Util.waitForTransactionToBeMined(this.web3, txHash)
-              .then(receipt => resolve(receipt))
-              .catch(e => reject(e))
+              miningPromise
+                .then(receipt => resolve(receipt))
+                .catch(e => reject(e))
+            } else {
+              resolve({
+                transactionHash: txHash,
+                miningPromise
+              });
             }
           }
         }
@@ -129,12 +136,17 @@ class Scheduler {
         (err, txHash) => {
           if (err) reject(err)
           else {
+            const miningPromise = Util.waitForTransactionToBeMined(this.web3, txHash);
+
             if (waitForMined) {
-              Util.waitForTransactionToBeMined(this.web3, txHash)
-              .then(receipt => resolve(receipt))
-              .catch(e => reject(e))
+              miningPromise
+                .then(receipt => resolve(receipt))
+                .catch(e => reject(e))
             } else {
-              resolve(txHash)
+              resolve({
+                transactionHash: txHash,
+                miningPromise
+              });
             }
           }
         }

--- a/src/scheduling/index.js
+++ b/src/scheduling/index.js
@@ -58,7 +58,8 @@ class Scheduler {
     gasPrice,
     fee,
     bounty,
-    requiredDeposit
+    requiredDeposit,
+    waitForMined = true
   ) {
     return new Promise((resolve, reject) => {
       this.blockScheduler.schedule.sendTransaction(
@@ -82,9 +83,11 @@ class Scheduler {
         (err, txHash) => {
           if (err) reject(err)
           else {
-            Util.waitForTransactionToBeMined(this.web3, txHash)
+            if (waitForMined) {
+              Util.waitForTransactionToBeMined(this.web3, txHash)
               .then(receipt => resolve(receipt))
               .catch(e => reject(e))
+            }
           }
         }
       )
@@ -101,7 +104,8 @@ class Scheduler {
     gasPrice,
     fee,
     bounty,
-    requiredDeposit
+    requiredDeposit,
+    waitForMined = true
   ) {
     return new Promise((resolve, reject) => {
       this.timestampScheduler.schedule(
@@ -125,9 +129,13 @@ class Scheduler {
         (err, txHash) => {
           if (err) reject(err)
           else {
-            Util.waitForTransactionToBeMined(this.web3, txHash)
+            if (waitForMined) {
+              Util.waitForTransactionToBeMined(this.web3, txHash)
               .then(receipt => resolve(receipt))
               .catch(e => reject(e))
+            } else {
+              resolve(txHash)
+            }
           }
         }
       )


### PR DESCRIPTION
In some cases we don't want to wait for transaction to be mined. On main net it can take hours. This would enable storing returning txHash instantly, then application using eac.js could for example store it and periodically check status even when user closes page. I'm talking about mostly web browser usage here.